### PR TITLE
refactor: migrate add component form to rhf

### DIFF
--- a/src/features/comments/components/add-comment/add-comment.tsx
+++ b/src/features/comments/components/add-comment/add-comment.tsx
@@ -4,24 +4,41 @@ import { Button } from "@/shared/components/ui/shadcn/button";
 import { Input } from "@/shared/components/ui/shadcn/input";
 import { useState } from "react";
 import { addComment } from "../../actions/add-comment";
+import { useUser } from "@clerk/nextjs";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const commentFormSchema = z.object({
+  comment: z
+    .string()
+    .min(1, { message: "Komentarz powinien być dłuższy niz 1 znak" }),
+});
 
 export const AddComment = ({ postId }: { postId: string }) => {
-  const [newComment, setNewComment] = useState("");
-  const onSubmit = async (evt: React.FormEvent) => {
-    evt.preventDefault();
-    await addComment({ content: newComment, postId: postId });
-    setNewComment("");
-  };
+  const user = useUser();
+  const { register, handleSubmit, setValue } = useForm({
+    resolver: zodResolver(commentFormSchema),
+    defaultValues: {
+      comment: "",
+    },
+  });
+  const onSubmit = handleSubmit(async (data: { comment: string }) => {
+    await addComment({ content: data.comment, postId: postId });
+    return setValue("comment", "");
+  });
   return (
     <form onSubmit={onSubmit} className="mb-6 flex w-full space-x-2">
       <Input
         type="text"
         placeholder="Dodaj komentarz"
-        value={newComment}
-        onChange={(e) => setNewComment(e.target.value)}
+        disabled={!user.isSignedIn}
+        {...register("comment")}
         className="flex-grow"
       />
-      <Button type="submit">Dodaj</Button>
+      <Button disabled={!user.isSignedIn} type="submit">
+        Dodaj
+      </Button>
     </form>
   );
 };

--- a/src/features/comments/components/add-comment/add-comment.tsx
+++ b/src/features/comments/components/add-comment/add-comment.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/shared/components/ui/shadcn/button";
 import { Input } from "@/shared/components/ui/shadcn/input";
-import { useState } from "react";
 import { addComment } from "../../actions/add-comment";
 import { useUser } from "@clerk/nextjs";
 import { useForm } from "react-hook-form";


### PR DESCRIPTION
## Summary by Sourcery

Refactor the add comment form to use React Hook Form and Zod. Disable the form if the user isn't logged in.

Enhancements:
- Migrate the add comment form to use React Hook Form and Zod for validation and state management.
- Disable the comment input and submit button if the user is not signed in using Clerk..